### PR TITLE
Meru800biac: add platform manager and services support

### DIFF
--- a/fboss/agent/Utils.cpp
+++ b/fboss/agent/Utils.cpp
@@ -1018,6 +1018,7 @@ uint32_t getRemotePortOffset(const PlatformType platformType) {
       return 0;
     case PlatformType::PLATFORM_MERU800BIA:
     case PlatformType::PLATFORM_MERU800BIAB:
+    case PlatformType::PLATFORM_MERU800BIAC:
     case PlatformType::PLATFORM_JANGA800BIC:
       return 1024;
 

--- a/fboss/platform/helpers/PlatformNameLib.cpp
+++ b/fboss/platform/helpers/PlatformNameLib.cpp
@@ -34,8 +34,9 @@ std::string sanitizePlatformName(const std::string& platformNameFromBios) {
     return "TAHAN800BC";
   }
 
-  // MERU800BIAB and MERU800BIA have equivalent configs
-  if (platformNameUpper == "MERU800BIAB") {
+  // MERU800BIAB, MERU800BIAC and MERU800BIA have equivalent configs
+  if (platformNameUpper == "MERU800BIAB" ||
+      platformNameUpper == "MERU800BIAC") {
     return "MERU800BIA";
   }
 

--- a/fboss/util/wedge_qsfp_util.cpp
+++ b/fboss/util/wedge_qsfp_util.cpp
@@ -4357,7 +4357,8 @@ std::pair<std::unique_ptr<TransceiverI2CApi>, int> getTransceiverAPI() {
       auto ioBus = std::make_unique<BspIOBus>(systemContainer);
       return std::make_pair(std::move(ioBus), 0);
     } else if (
-        FLAGS_platform == "meru800bia" || FLAGS_platform == "meru800biab") {
+        FLAGS_platform == "meru800bia" || FLAGS_platform == "meru800biab" ||
+        FLAGS_platform == "meru800biac") {
       auto systemContainer =
           BspGenericSystemContainer<Meru800biaBspPlatformMapping>::getInstance()
               .get();
@@ -4435,7 +4436,8 @@ std::pair<std::unique_ptr<TransceiverI2CApi>, int> getTransceiverAPI() {
     return std::make_pair(std::move(ioBus), 0);
   } else if (
       mode == PlatformType::PLATFORM_MERU800BIA ||
-      mode == PlatformType::PLATFORM_MERU800BIAB) {
+      mode == PlatformType::PLATFORM_MERU800BIAB ||
+      mode == PlatformType::PLATFORM_MERU800BIAC) {
     auto systemContainer =
         BspGenericSystemContainer<Meru800biaBspPlatformMapping>::getInstance()
             .get();
@@ -4560,7 +4562,8 @@ getTransceiverPlatformAPI(TransceiverI2CApi* i2cBus) {
         std::make_unique<BspTransceiverApi>(systemContainer), 0);
   } else if (
       mode == PlatformType::PLATFORM_MERU800BIA ||
-      mode == PlatformType::PLATFORM_MERU800BIAB) {
+      mode == PlatformType::PLATFORM_MERU800BIAB ||
+      mode == PlatformType::PLATFORM_MERU800BIAC) {
     auto systemContainer =
         BspGenericSystemContainer<Meru800biaBspPlatformMapping>::getInstance()
             .get();


### PR DESCRIPTION
# Description

> NOTE: This is part of a series of PRs to add support for Meru800biac. The dependency chain of the PRs is as follows:
> 
> Meru800biac: define new platform #1 
> Meru800biac: add bsp mapping and platform mapping #2 - Depends on #1
> Meru800biac: add platform manager and services support #3 - Depends on #2

Meru800biac will use the same configs as Meru800bia:
 - Added Merubia reference to initialize PM, agent, sensor_service, fan_service
 - Added support for fw_util, wedge_qsfp_util

# Testing
## platform_manager
platform_manager use the same config as meru800bia and succeed 
```
Jul 28 14:14:04 vpr405.sjc.aristanetworks.com systemd[1]: Starting FBOSS Platform Manager...
Jul 28 14:14:04 vpr405.sjc.aristanetworks.com platform_manager[5831]: I0728 14:14:04.249903  5831 PlatformNameLib.cpp:56] Getting platform name from bios using dmidecode ...
Jul 28 14:14:04 vpr405.sjc.aristanetworks.com platform_manager[5831]: I0728 14:14:04.254264  5831 PlatformNameLib.cpp:65] Platform name inferred from bios: MERU800BIAC
Jul 28 14:14:04 vpr405.sjc.aristanetworks.com platform_manager[5831]: I0728 14:14:04.254272  5831 PlatformNameLib.cpp:67] Platform name mapped: MERU800BIA
Jul 28 14:14:04 vpr405.sjc.aristanetworks.com platform_manager[5831]: I0728 14:14:04.255227  5831 ConfigLib.cpp:33] Using config file: /opt/fboss/share/platform_configs/platform_manager.json
Jul 28 14:14:04 vpr405.sjc.aristanetworks.com platform_manager[5831]: I0728 14:14:04.255722  5831 ConfigValidator.cpp:470] Validating the config
...
Jul 28 14:14:17 vpr405.sjc.aristanetworks.com platform_manager[5831]: I0728 14:14:17.402822  5831 PlatformExplorer.cpp:765] Reporting firmware version for FAN_CPLD - version string:1.9
Jul 28 14:14:17 vpr405.sjc.aristanetworks.com platform_manager[5831]: I0728 14:14:17.402864  5831 PlatformExplorer.cpp:765] Reporting firmware version for MERU800BIA_SMB_FPGA_INFO_ROM - version string:4.17
Jul 28 14:14:17 vpr405.sjc.aristanetworks.com platform_manager[5831]: I0728 14:14:17.402892  5831 PlatformExplorer.cpp:765] Reporting firmware version for MERU_SCM_CPLD_INFO_ROM - version string:4.16
Jul 28 14:14:17 vpr405.sjc.aristanetworks.com platform_manager[5831]: I0728 14:14:17.402970  5831 PlatformExplorer.cpp:792] Reporting Production State: 3
Jul 28 14:14:17 vpr405.sjc.aristanetworks.com platform_manager[5831]: I0728 14:14:17.402976  5831 PlatformExplorer.cpp:800] Reporting Production Sub-State: 1
Jul 28 14:14:17 vpr405.sjc.aristanetworks.com platform_manager[5831]: I0728 14:14:17.402980  5831 PlatformExplorer.cpp:810] Reporting Variant Indicator: 0
Jul 28 14:14:17 vpr405.sjc.aristanetworks.com platform_manager[5831]: I0728 14:14:17.402992  5831 ExplorationSummary.cpp:49] Successfully explored meru800bia...
Jul 28 14:14:17 vpr405.sjc.aristanetworks.com platform_manager[5831]: I0728 14:14:17.403054  5831 Main.cpp:43] Sent sd_notify ready by running command
Jul 28 14:14:17 vpr405.sjc.aristanetworks.com platform_manager[5831]: I0728 14:14:17.403079  5831 Main.cpp:84] Running PlatformManager thrift service...
Jul 28 14:14:17 vpr405.sjc.aristanetworks.com systemd[1]: Started FBOSS Platform Manager.
Jul 28 14:14:17 vpr405.sjc.aristanetworks.com platform_manager[5831]: I0728 14:14:17.403828  5831 ThriftServer.cpp:973] Using resource pools on address/port 5975: thrift flag: true, enable gflag: false, disable gflag: false, runtime actions:
Jul 28 14:14:17 vpr405.sjc.aristanetworks.com platform_manager[5831]: I0728 14:14:17.404667  5831 ThriftServer.cpp:1530] Resource pools configured: 6
```
## sensor_service
sensor_service is running and uses the same config as meru800bia
```
Jul 28 14:14:17 vpr405.sjc.aristanetworks.com systemd[1]: Started Start sensor_service.
Jul 28 14:14:17 vpr405.sjc.aristanetworks.com run_sensor_service.sh[6102]: I0728 14:14:17.452311  6102 PlatformNameLib.cpp:79] Platform name read from cache: MERU800BIA
Jul 28 14:14:17 vpr405.sjc.aristanetworks.com run_sensor_service.sh[6102]: I0728 14:14:17.452351  6102 ConfigLib.cpp:33] Using config file: /opt/fboss/share/platform_configs/sensor_service.json
Jul 28 14:14:17 vpr405.sjc.aristanetworks.com run_sensor_service.sh[6102]: I0728 14:14:17.452935  6102 SensorServiceImpl.cpp:90] Reading SensorData for 4 PMUnits
Jul 28 14:14:17 vpr405.sjc.aristanetworks.com run_sensor_service.sh[6102]: I0728 14:14:17.452945  6102 SensorServiceImpl.cpp:95] Processing SCM PMUnit: 13 sensors
Jul 28 14:14:17 vpr405.sjc.aristanetworks.com run_sensor_service.sh[6102]: I0728 14:14:17.462058  6102 SensorServiceImpl.cpp:95] Processing SMB PMUnit: 49 sensors
Jul 28 14:14:17 vpr405.sjc.aristanetworks.com run_sensor_service.sh[6102]: I0728 14:14:17.592921  6102 SensorServiceImpl.cpp:95] Processing PSU PMUnit: 11 sensors
Jul 28 14:14:17 vpr405.sjc.aristanetworks.com run_sensor_service.sh[6102]: I0728 14:14:17.604096  6102 SensorServiceImpl.cpp:95] Processing PSU PMUnit: 11 sensors
Jul 28 14:14:17 vpr405.sjc.aristanetworks.com run_sensor_service.sh[6102]: I0728 14:14:17.615046  6102 SensorServiceImpl.cpp:126] Summary: Processed 84 Sensors. 0 Failures.
```
[sensor_service_sw_test.txt](https://github.com/user-attachments/files/21472483/sensor_service_sw_test.txt) PASSED

## fan_service
fan_service is running and uses the same config as meru800bia
```
Jul 28 15:25:21 vpr405.sjc.aristanetworks.com systemd[1]: Started Start fan_service.
Jul 28 15:25:21 vpr405.sjc.aristanetworks.com run_fan_service.sh[6142]: I0728 15:25:21.859809  6142 PlatformNameLib.cpp:79] Platform name read from cache: MERU800BIA
Jul 28 15:25:21 vpr405.sjc.aristanetworks.com run_fan_service.sh[6142]: I0728 15:25:21.859840  6142 ConfigLib.cpp:33] Using config file: /opt/fboss/share/platform_configs/fan_service.json
Jul 28 15:25:21 vpr405.sjc.aristanetworks.com run_fan_service.sh[6142]: I0728 15:25:21.859937  6142 Main.cpp:53] {"shutdownCmd":"","zones":[{"zoneType":"ZONE_TYPE_MAX","zoneName":"zone1","sensorNames":["SMB_BOARD_FRONT_TEMP","osfp_group_1"],">
Jul 28 15:25:21 vpr405.sjc.aristanetworks.com run_fan_service.sh[6142]: I0728 15:25:21.859953  6142 ConfigValidator.cpp:101] The config is valid
Jul 28 15:25:21 vpr405.sjc.aristanetworks.com run_fan_service.sh[6142]: I0728 15:25:21.860865  6142 ControlLogic.cpp:59] Upon fan_service start up, program all fan pwm with transitional value of 50
Jul 28 15:25:21 vpr405.sjc.aristanetworks.com run_fan_service.sh[6142]: I0728 15:25:21.863331  6142 ControlLogic.cpp:439] fan_1: Programmed with PWM 50 (raw value 128)
Jul 28 15:25:21 vpr405.sjc.aristanetworks.com run_fan_service.sh[6142]: I0728 15:25:21.866356  6142 ControlLogic.cpp:439] fan_2: Programmed with PWM 50 (raw value 128)
Jul 28 15:25:21 vpr405.sjc.aristanetworks.com run_fan_service.sh[6142]: I0728 15:25:21.869326  6142 ControlLogic.cpp:439] fan_3: Programmed with PWM 50 (raw value 128)
Jul 28 15:25:21 vpr405.sjc.aristanetworks.com run_fan_service.sh[6142]: I0728 15:25:21.872325  6142 ControlLogic.cpp:439] fan_4: Programmed with PWM 50 (raw value 128)
Jul 28 15:25:21 vpr405.sjc.aristanetworks.com run_fan_service.sh[6142]: I0728 15:25:21.872339  6142 FanServiceHandler.cpp:11] FanServiceHandler Started
...
```
[fan_service_hw_test.txt](https://github.com/user-attachments/files/21473724/fan_service_hw_test.txt)

## wedge_qsfp_util
```
# wedge_qsfp_util eth1/14/1
I0729 18:44:16.600040  7186 PlatformProductInfo.cpp:356] Success parsing product info fields
I0729 18:44:16.600830  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_1
I0729 18:44:16.600914  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_2
I0729 18:44:16.600987  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_3
I0729 18:44:16.601052  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_4
I0729 18:44:16.601110  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_5
I0729 18:44:16.601190  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_6
I0729 18:44:16.601251  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_7
I0729 18:44:16.601321  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_8
I0729 18:44:16.601367  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_9
I0729 18:44:16.601429  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_10
I0729 18:44:16.601478  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_11
I0729 18:44:16.601541  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_12
I0729 18:44:16.601601  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_13
I0729 18:44:16.601650  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_14
I0729 18:44:16.601699  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_15
I0729 18:44:16.601750  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_16
I0729 18:44:16.601797  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_17
I0729 18:44:16.601858  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_18
I0729 18:44:16.601905  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_19
I0729 18:44:16.601962  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_20
I0729 18:44:16.602012  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_21
I0729 18:44:16.602062  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_22
I0729 18:44:16.602107  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_23
I0729 18:44:16.602162  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_24
I0729 18:44:16.602221  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_25
I0729 18:44:16.602274  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_26
I0729 18:44:16.602328  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_27
I0729 18:44:16.602373  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_28
I0729 18:44:16.602419  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_29
I0729 18:44:16.602472  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_30
I0729 18:44:16.602522  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_31
I0729 18:44:16.602576  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_32
I0729 18:44:16.602623  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_33
I0729 18:44:16.602677  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_34
I0729 18:44:16.602731  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_35
I0729 18:44:16.602781  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_36
I0729 18:44:16.602841  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_37
I0729 18:44:16.602890  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_38
I0729 18:44:16.602940  7186 I2cDevIo.cpp:85] Creating I2cRdWrIo for /run/devmap/xcvrs/xcvr_io_39
I0729 18:44:16.603114  7186 PlatformProductInfo.cpp:356] Success parsing product info fields
E0729 18:44:16.613888  7186 FbossFwStorage.cpp:28] Bad config yaml file /lib/firmware/fboss/fboss_firmware.yaml bad file
E0729 18:44:16.613925  7186 TransceiverManager.cpp:167] Couldn't create FbossFwStorage instance: YAML::BadFile: bad file
E0729 18:44:16.613934  7186 TransceiverManager.cpp:210] Did not find transceiver id for port id 1
E0729 18:44:16.613940  7186 TransceiverManager.cpp:210] Did not find transceiver id for port id 2
E0729 18:44:16.613944  7186 TransceiverManager.cpp:210] Did not find transceiver id for port id 3
E0729 18:44:16.613948  7186 TransceiverManager.cpp:210] Did not find transceiver id for port id 4
E0729 18:44:16.613953  7186 TransceiverManager.cpp:210] Did not find transceiver id for port id 5
E0729 18:44:16.613957  7186 TransceiverManager.cpp:210] Did not find transceiver id for port id 6
I0729 18:44:16.617844  7186 BspWedgeManager.cpp:19] BspTrace: BspWedgeManager()
Port 14
Logical Ports: eth1/14/1, eth1/14/5
  Transceiver Management Interface: CMIS
  Module State: READY
    StateMachine State: ACTIVE
  Module Media Interface: FR4_2x400G
  Current Media Interface: FR4_400G
  Power Control: HIGH_POWER_OVERRIDE
  FW Version: 3.7
  Firmware fault: 0x0
  EEPROM Checksum: Valid
  Host Lane Signals:       Lane 1       Lane 2       Lane 3       Lane 4       Lane 5       Lane 6       Lane 7       Lane 8
    Tx LOS                 0            0            0            0            0            0            0            0
    Tx LOL                 0            0            0            0            0            0            0            0
    Tx Adaptive Eq Fault   0            0            0            0            0            0            0            0
    Datapath de-init       0            0            0            0            0            0            0            0
    Lane state             ACTIVATED    ACTIVATED    ACTIVATED    ACTIVATED    ACTIVATED    ACTIVATED    ACTIVATED    ACTIVATED
  Media Lane Signals:      Lane 1       Lane 2       Lane 3       Lane 4       Lane 5       Lane 6       Lane 7       Lane 8
    Rx LOS                 0            0            0            0            0            0            0            0
    Rx LOL                 0            0            0            0            0            0            0            0
    Tx Fault               0            0            0            0            0            0            0            0
  Host Lane Settings:      Lane 1       Lane 2       Lane 3       Lane 4       Lane 5       Lane 6       Lane 7       Lane 8
    Rx Out Precursor       6            6            6            6            6            6            6            6
    Rx Out Postcursor      0            0            0            0            0            0            0            0
    Rx Out Amplitude       2            2            2            2            2            2            2            2
    Rx Output Disable      0            0            0            0            0            0            0            0
    Rx Squelch Disable     0            0            0            0            0            0            0            0
  Media Lane Settings:     Lane 1       Lane 2       Lane 3       Lane 4       Lane 5       Lane 6       Lane 7       Lane 8
    Tx Disable             0            0            0            0            0            0            0            0
    Tx Squelch Disable     0            0            0            0            0            0            0            0
    Tx Forced Squelch      0            0            0            0            0            0            0            0
  Lane Dom Monitors:       Lane 1       Lane 2       Lane 3       Lane 4       Lane 5       Lane 6       Lane 7       Lane 8
    Tx Pwr (mW)            1.28         1.14         1.50         1.43         1.36         1.38         1.61         1.42
    Tx Pwr (dBm)           1.07         0.56         1.75         1.54         1.33         1.38         2.07         1.54
    Rx Pwr (mW)            1.50         1.45         1.37         1.39         1.43         1.49         1.56         1.58
    Rx Pwr (dBm)           1.77         1.62         1.38         1.43         1.56         1.73         1.93         1.99
    Tx Bias (mA)           85.20        91.43        70.30        70.40        70.20        100.16       105.29       108.51
    Rx SNR                 0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00
  Global DOM Monitors:
    Temperature: 64.14 C
    Supply Voltage: 3.28 V
  Vendor Info:
    Vendor: Arista Networks
    Vendor PN: OSFP-800G-2FR4
    Vendor Rev: 50
    Vendor SN: XKT240404739
    Date Code: 241230
  Time collected: Tue Jul 29 18:43:59 2025
```